### PR TITLE
fix: dependency issues when publishing rancher with latest operator version

### DIFF
--- a/.github/workflows/latest-rancher-build.yaml
+++ b/.github/workflows/latest-rancher-build.yaml
@@ -7,6 +7,11 @@ on:
         required: true
         default: "release/v2.8"
         type: string
+      operator_name:
+        description: "Operator name"
+        required: true
+        default: ""
+        type: string
       operator_repo:
         description: "Operator repo (e.g. github.com/rancher/aks-operator)"
         required: true
@@ -28,6 +33,7 @@ on:
         type: string
 
 env:
+  OPERATOR_NAME: ${{inputs.operator_name}}
   OPERATOR_REPO: ${{inputs.operator_repo}}
   OPERATOR_COMMIT: ${{inputs.operator_commit}}
   RANCHER_IMAGE: ${{inputs.rancher_image}}

--- a/.github/workflows/operator-with-latest-rancher-build.yaml
+++ b/.github/workflows/operator-with-latest-rancher-build.yaml
@@ -112,6 +112,7 @@ jobs:
     uses: rancher-sandbox/highlander-reusable-workflows/.github/workflows/latest-rancher-build.yaml@main
     with:
       rancher_ref: ${{ inputs.rancher_ref }}
+      operator_name: ${{ inputs.operator_name }}
       operator_repo: github.com/rancher/${{ inputs.operator_name }}
       operator_commit: ${{ inputs.operator_commit }}
       rancher_image: ttl.sh/rancher-${{ inputs.operator_name }}-nightly-${{ needs.set_build_date.outputs.BUILD_DATE }}

--- a/latest-rancher-build.sh
+++ b/latest-rancher-build.sh
@@ -11,11 +11,12 @@ else
 fi
 
 # Update operator dependencies
+CURRENT_OPERATOR_VERSION=$(go list -m all | grep ${OPERATOR_NAME} | awk '{print $2}')
 cd "${RANCHER_DIR}"
-go get "${OPERATOR_REPO}@${OPERATOR_COMMIT}"
+go mod edit -replace=${OPERATOR_REPO}@${CURRENT_OPERATOR_VERSION}=${OPERATOR_REPO}@${OPERATOR_COMMIT}
 go mod tidy
 cd pkg/apis
-go get "${OPERATOR_REPO}@${OPERATOR_COMMIT}"
+go mod edit -replace=${OPERATOR_REPO}@${CURRENT_OPERATOR_VERSION}=${OPERATOR_REPO}@${OPERATOR_COMMIT}
 go mod tidy
 cd ../../
 


### PR DESCRIPTION
### Description

Hosted providers' nightly publish workflow is failing when the last step in the action tries to build `rancher:v2.8` with the latest unpublished version of the operator as `go get` is generating dependency conflicts in the repository, as seen [here](https://github.com/rancher/aks-operator/actions/runs/7256328822). This uses `replace` instead to address this issue and update Rancher's operator version.

### Issue
Fixes #2 