### PR TITLE
fix: getting go.mod from outside rancher folder

### DIFF
--- a/latest-rancher-build.sh
+++ b/latest-rancher-build.sh
@@ -11,8 +11,8 @@ else
 fi
 
 # Update operator dependencies
-CURRENT_OPERATOR_VERSION=$(go list -m all | grep ${OPERATOR_NAME} | awk '{print $2}')
 cd "${RANCHER_DIR}"
+CURRENT_OPERATOR_VERSION=$(go list -m all | grep ${OPERATOR_NAME} | awk '{print $2}')
 go mod edit -replace=${OPERATOR_REPO}@${CURRENT_OPERATOR_VERSION}=${OPERATOR_REPO}@${OPERATOR_COMMIT}
 go mod tidy
 cd pkg/apis


### PR DESCRIPTION
### Description

This fixes an error (see [here](https://github.com/rancher/eks-operator/actions/runs/7286945475/job/19856943090)) when getting the hosted providers' current required version in Rancher's `go.mod` which was caused by being out of the Rancher directory when listing required modules.