### PR TITLE
Update operator default branch

### DIFF
--- a/.github/workflows/operator-with-latest-rancher-build.yaml
+++ b/.github/workflows/operator-with-latest-rancher-build.yaml
@@ -77,7 +77,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: rancher/${{ inputs.operator_name }}
-          ref: master
+          ref: main
           path: ${{ inputs.operator_name }}
       - name: Install Helm
         uses: azure/setup-helm@v3


### PR DESCRIPTION
Update operator default branch name for running nightly publish workflows
Fixes failing job: https://github.com/rancher/eks-operator/actions/runs/7564270174/job/20598311213#step:2:590