### PR TITLE
ci: Update GH actions

### DIFF
--- a/.github/workflows/latest-rancher-build.yaml
+++ b/.github/workflows/latest-rancher-build.yaml
@@ -51,14 +51,14 @@ jobs:
         with:
           version: 'v3.12.1'
       - name: Checkout highlander-reusable-workflows
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           repository: rancher-sandbox/highlander-reusable-workflows
           ref: "main"
           path: highlander-reusable-workflows
       - name: Checkout rancher/rancher
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           repository: rancher/rancher

--- a/.github/workflows/operator-with-latest-rancher-build.yaml
+++ b/.github/workflows/operator-with-latest-rancher-build.yaml
@@ -105,15 +105,4 @@ jobs:
         with:
           name: rancher-${{ inputs.operator_name }}-crd-${{ env.BUILD_DATE }}.tgz
           path: ${{ inputs.operator_name }}/bin/rancher-${{ inputs.operator_name }}-crd-${{ env.BUILD_DATE }}.tgz 
-  nightly_custom_rancher_charts:
-    needs: 
-      - set_build_date
-      - nightly_operator_charts
-    uses: rancher-sandbox/highlander-reusable-workflows/.github/workflows/latest-rancher-build.yaml@main
-    with:
-      rancher_ref: ${{ inputs.rancher_ref }}
-      operator_name: ${{ inputs.operator_name }}
-      operator_repo: github.com/rancher/${{ inputs.operator_name }}
-      operator_commit: ${{ inputs.operator_commit }}
-      rancher_image: ttl.sh/rancher-${{ inputs.operator_name }}-nightly-${{ needs.set_build_date.outputs.BUILD_DATE }}
-      rancher_helm_repo:  oci://ttl.sh/rancher-${{ inputs.operator_name }}-nightly
+  

--- a/.github/workflows/operator-with-latest-rancher-build.yaml
+++ b/.github/workflows/operator-with-latest-rancher-build.yaml
@@ -36,14 +36,14 @@ jobs:
     needs: set_build_date
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
             fetch-depth: 0
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2.10.0
+        uses: docker/setup-buildx-action@v3
       - name: Build and push image
-        uses: docker/build-push-action@v4.1.1
+        uses: docker/build-push-action@v6
         with:
           context: .
           tags: ${{ env.OPERATOR_IMAGE_REPO_BASE}}-${{ env.BUILD_DATE }}:${{ env.TAG }}
@@ -73,14 +73,14 @@ jobs:
       - nightly_image
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           repository: rancher/${{ inputs.operator_name }}
           ref: main
           path: ${{ inputs.operator_name }}
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4
         with:
             version: 'v3.12.1'
       - name: Build charts

--- a/.github/workflows/update-rancher-charts.yaml
+++ b/.github/workflows/update-rancher-charts.yaml
@@ -53,13 +53,13 @@ jobs:
   create-rancher-charts-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: main
           path: highlander-reusable-workflows
       - name: Checkout rancher/charts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           repository: rancher/charts

--- a/.github/workflows/update-rancher-dep.yaml
+++ b/.github/workflows/update-rancher-dep.yaml
@@ -32,13 +32,13 @@ jobs:
   create-rancher-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: main
           path: highlander-reusable-workflows
       - name: Checkout rancher/rancher
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           repository: rancher/rancher


### PR DESCRIPTION
Update some of the actions to the latest version:
- actions/checkout@v4
- docker/setup-buildx-action@v3
- docker/build-push-action@v6
- azure/setup-helm@v4

Also removed last step that created custom charts because the operators are being installed directly i.e. as described in https://confluence.suse.com/display/EN/Testing+using+HEAD